### PR TITLE
Add layered Jest test suite

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const authRoutes = require('./routes/auth');
+const bookRoutes = require('./routes/books');
+const rentalRoutes = require('./routes/rentals');
+
+const app = express();
+app.use(express.json());
+
+app.use('/auth', authRoutes);
+app.use('/books', bookRoutes);
+app.use('/rentals', rentalRoutes);
+
+module.exports = app;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "jest": "^29.7.0",
         "jest-html-reporters": "^3.1.5",
+        "mongodb-memory-server": "^10.1.4",
         "nodemon": "^3.1.0",
         "supertest": "^6.3.3"
       }
@@ -1326,12 +1327,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -1465,6 +1483,14 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/bcrypt": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
@@ -1589,6 +1615,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -1841,6 +1877,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -2347,6 +2390,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2402,6 +2452,24 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2414,6 +2482,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/form-data": {
@@ -4226,6 +4315,107 @@
         "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.1.4.tgz",
+      "integrity": "sha512-+oKQ/kc3CX+816oPFRtaF0CN4vNcGKNjpOQe4bHo/21A3pMD+lC7Xz1EX5HP7siCX4iCpVchDMmCOFXVQSGkUg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "10.1.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.1.4.tgz",
+      "integrity": "sha512-o8fgY7ZalEd8pGps43fFPr/hkQu1L8i6HFEGbsTfA2zDOW0TopgpswaBCqDr0qD7ptibyPfB5DmC+UlIxbThzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.7",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.9",
+        "https-proxy-agent": "^7.0.5",
+        "mongodb": "^6.9.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.6.3",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.7.0",
+        "yauzl": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mongoose": {
       "version": "8.15.1",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.15.1.tgz",
@@ -4319,6 +4509,44 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "5.1.0",
@@ -4709,6 +4937,13 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -5295,6 +5530,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5495,6 +5744,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -5514,6 +5775,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tmpl": {
@@ -5566,6 +5837,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -5843,6 +6121,20 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Backend API for managing book rentals",
   "main": "server.js",
   "scripts": {
-    "start": "node app.js",
-    "dev": "nodemon app.js",
+    "start": "node server.js",
+    "dev": "nodemon server.js",
     "test": "jest --runInBand",
     "test:report": "jest --reporters=default --reporters=jest-html-reporters"
   },
@@ -18,13 +18,14 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
-    "supertest": "^6.3.3",
+    "jest-html-reporters": "^3.1.5",
+    "mongodb-memory-server": "^10.1.4",
     "nodemon": "^3.1.0",
-    "jest-html-reporters": "^3.1.5"
+    "supertest": "^6.3.3"
   },
-  
   "jest": {
     "testEnvironment": "node",
+    "setupFilesAfterEnv": ["<rootDir>/tests/setup.js"],
     "reporters": [
       "default",
       [
@@ -37,7 +38,6 @@
       ]
     ]
   },
-
   "keywords": [
     "books",
     "rental",

--- a/server.js
+++ b/server.js
@@ -1,18 +1,8 @@
-const express = require('express');
 const mongoose = require('mongoose');
 const dotenv = require('dotenv');
-const authRoutes = require('./routes/auth');
-const bookRoutes = require('./routes/books');
-const rentalRoutes = require('./routes/rentals');
+const app = require('./app');
 
 dotenv.config();
-
-const app = express();
-app.use(express.json());
-
-app.use('/auth', authRoutes);
-app.use('/books', bookRoutes);
-app.use('/rentals', rentalRoutes);
 
 const PORT = process.env.PORT || 5000;
 
@@ -20,7 +10,9 @@ mongoose
   .connect(process.env.MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true })
   .then(() => {
     console.log('MongoDB connected');
-    app.listen(PORT, () => console.log(`Server running on port: ${PORT}`));
+    if (process.env.NODE_ENV !== 'test') {
+      app.listen(PORT, () => console.log(`Server running on port: ${PORT}`));
+    }
   })
   .catch(err => console.log(err));
 

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,86 @@
+const request = require('supertest');
+const app = require('../app');
+const User = require('../models/user');
+
+// --- Layer 1: Basic Functional Tests for /auth
+describe('Auth Endpoints - Basic', () => {
+  test('should register a new user and return token', async () => {
+    const res = await request(app).post('/auth/register').send({
+      name: 'John',
+      email: 'john@example.com',
+      password: 'password'
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toHaveProperty('token');
+  });
+
+  test('should login an existing user and return token', async () => {
+    await request(app).post('/auth/register').send({
+      name: 'Jane',
+      email: 'jane@example.com',
+      password: 'password'
+    });
+    const res = await request(app).post('/auth/login').send({
+      email: 'jane@example.com',
+      password: 'password'
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('token');
+  });
+});
+
+// --- Layer 2: Edge Case & Validation Testing for /auth
+describe('Auth Endpoints - Edge Cases', () => {
+  test('should not allow duplicate email registration', async () => {
+    await request(app).post('/auth/register').send({
+      name: 'Dup',
+      email: 'dup@example.com',
+      password: 'password'
+    });
+    const res = await request(app).post('/auth/register').send({
+      name: 'Dup2',
+      email: 'dup@example.com',
+      password: 'password'
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('should reject login with wrong password', async () => {
+    await request(app).post('/auth/register').send({
+      name: 'Mark',
+      email: 'mark@example.com',
+      password: 'password'
+    });
+    const res = await request(app).post('/auth/login').send({
+      email: 'mark@example.com',
+      password: 'wrong'
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// --- Layer 3: Out-of-the-Box & Production Practices for /auth
+describe('Auth Endpoints - Production Scenarios', () => {
+  test('should handle very long names on register', async () => {
+    const longName = 'a'.repeat(1000);
+    const res = await request(app).post('/auth/register').send({
+      name: longName,
+      email: `long${Date.now()}@example.com`,
+      password: 'password'
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toHaveProperty('token');
+  });
+
+  test('should reject login when password is missing', async () => {
+    await request(app).post('/auth/register').send({
+      name: 'NoPass',
+      email: 'nopass@example.com',
+      password: 'password'
+    });
+    const res = await request(app).post('/auth/login').send({
+      email: 'nopass@example.com'
+    });
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/tests/books.test.js
+++ b/tests/books.test.js
@@ -1,0 +1,76 @@
+const request = require('supertest');
+const app = require('../app');
+const Book = require('../models/Book');
+const { createUserToken, createBook } = require('./utils');
+
+// --- Layer 1: Basic Functional Tests for /books
+describe('Book Endpoints - Basic', () => {
+  test('should list books (empty array initially)', async () => {
+    const res = await request(app).get('/books');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  test('admin can add and retrieve a book', async () => {
+    const { token } = await createUserToken('admin');
+    const book = await createBook(token, { title: 'Book A' });
+
+    const res = await request(app).get(`/books/${book._id}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.title).toBe('Book A');
+  });
+
+  test('admin can update and delete a book', async () => {
+    const { token } = await createUserToken('admin');
+    const book = await createBook(token, { title: 'Book B' });
+
+    const update = await request(app)
+      .put(`/books/${book._id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Updated Book' });
+    expect(update.statusCode).toBe(200);
+    expect(update.body.title).toBe('Updated Book');
+
+    const del = await request(app)
+      .delete(`/books/${book._id}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(del.statusCode).toBe(200);
+    expect(del.body.message).toBe('Book deleted');
+  });
+});
+
+// --- Layer 2: Edge Case & Validation Testing for /books
+describe('Book Endpoints - Edge Cases', () => {
+  test('non-admin cannot add a book', async () => {
+    const { token } = await createUserToken('user');
+    const res = await request(app)
+      .post('/books')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Fail Book', author: 'X', stock: 1 });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('get book with invalid id returns 404', async () => {
+    const res = await request(app).get('/books/612345678901234567890123');
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// --- Layer 3: Out-of-the-Box & Production Practices for /books
+describe('Book Endpoints - Production Scenarios', () => {
+  test('should handle long title when adding book', async () => {
+    const { token } = await createUserToken('admin');
+    const longTitle = 'b'.repeat(500);
+    const res = await request(app)
+      .post('/books')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: longTitle, author: 'Author', stock: 1 });
+    expect(res.statusCode).toBe(201);
+    expect(res.body.title).toBe(longTitle);
+  });
+
+  test('missing auth header results in 401', async () => {
+    const res = await request(app).post('/books').send({ title: 'X', author: 'Y', stock: 1 });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/tests/rentals.test.js
+++ b/tests/rentals.test.js
@@ -1,0 +1,105 @@
+const request = require('supertest');
+const app = require('../app');
+const Book = require('../models/Book');
+const Rental = require('../models/Rental');
+const { createUserToken, createBook } = require('./utils');
+
+// --- Layer 1: Basic Functional Tests for /rentals
+describe('Rental Endpoints - Basic', () => {
+  test('user can rent and return a book', async () => {
+    const { token } = await createUserToken('user');
+    const admin = await createUserToken('admin');
+    const book = await createBook(admin.token, { stock: 2 });
+
+    const rentRes = await request(app)
+      .post('/rentals')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bookId: book._id });
+    expect(rentRes.statusCode).toBe(201);
+
+    const returnRes = await request(app)
+      .post('/rentals/return')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bookId: book._id });
+    expect(returnRes.statusCode).toBe(200);
+    expect(returnRes.body.message).toBe('Book returned');
+  });
+
+  test('user can view rental history', async () => {
+    const { token } = await createUserToken('user');
+    const admin = await createUserToken('admin');
+    const book = await createBook(admin.token);
+
+    await request(app)
+      .post('/rentals')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bookId: book._id });
+
+    const res = await request(app)
+      .get('/rentals/history')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+  });
+});
+
+// --- Layer 2: Edge Case & Validation Testing for /rentals
+describe('Rental Endpoints - Edge Cases', () => {
+  test('cannot rent unavailable book', async () => {
+    const admin = await createUserToken('admin');
+    const { token } = await createUserToken('user');
+    const book = await createBook(admin.token, { stock: 0 });
+
+    const res = await request(app)
+      .post('/rentals')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bookId: book._id });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('returning non-rented book fails', async () => {
+    const { token } = await createUserToken('user');
+    const admin = await createUserToken('admin');
+    const book = await createBook(admin.token);
+
+    const res = await request(app)
+      .post('/rentals/return')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bookId: book._id });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('access history without auth should fail', async () => {
+    const res = await request(app).get('/rentals/history');
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// --- Layer 3: Out-of-the-Box & Production Practices for /rentals
+describe('Rental Endpoints - Production Scenarios', () => {
+  test('should not allow renting same book twice without return', async () => {
+    const user = await createUserToken('user');
+    const admin = await createUserToken('admin');
+    const book = await createBook(admin.token);
+
+    await request(app)
+      .post('/rentals')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({ bookId: book._id });
+
+    const res = await request(app)
+      .post('/rentals')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({ bookId: book._id });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('missing token results in 401 when renting', async () => {
+    const admin = await createUserToken('admin');
+    const book = await createBook(admin.token);
+
+    const res = await request(app).post('/rentals').send({ bookId: book._id });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,27 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongo;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongo = await MongoMemoryServer.create();
+  const uri = mongo.getUri();
+  await mongoose.connect(uri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+});
+
+afterEach(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key of Object.keys(collections)) {
+    await collections[key].deleteMany({});
+  }
+});
+
+afterAll(async () => {
+  await mongoose.connection.dropDatabase();
+  await mongoose.connection.close();
+  await mongo.stop();
+});

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,32 @@
+const jwt = require('jsonwebtoken');
+const User = require('../models/user');
+const Book = require('../models/Book');
+
+exports.createUserToken = async (role = 'user', overrides = {}) => {
+  const user = new User({
+    name: 'Test User',
+    email: `user${Date.now()}@example.com`,
+    password: 'password',
+    role,
+    ...overrides,
+  });
+  await user.save();
+  const token = jwt.sign({ id: user._id, role: user.role }, process.env.JWT_SECRET);
+  return { user, token };
+};
+
+exports.createBook = async (adminToken, overrides = {}) => {
+  const request = require('supertest');
+  const app = require('../app');
+  const data = {
+    title: 'Test Book',
+    author: 'Some Author',
+    stock: 3,
+    ...overrides,
+  };
+  const res = await request(app)
+    .post('/books')
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send(data);
+  return res.body;
+};


### PR DESCRIPTION
## Summary
- create Express app module for easier testing
- update server to use new app module
- adjust npm scripts and add in-memory MongoDB setup
- implement Jest tests for auth, books, and rentals endpoints

## Testing
- `npm test` *(fails: DownloadError for MongoMemoryServer)*

------
https://chatgpt.com/codex/tasks/task_e_6842a6fed49c8333a95c0e5d71eb418d