### PR TITLE
Add extra coverage for API endpoints

### DIFF
--- a/tests/generated/routes/authExtra.test.js
+++ b/tests/generated/routes/authExtra.test.js
@@ -1,0 +1,42 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const jwt = require('jsonwebtoken');
+const app = require('../../../app');
+let mongoServer;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongoServer = await MongoMemoryServer.create({ binary: { version: '4.4.10' } });
+  await mongoose.connect(mongoServer.getUri(), { useNewUrlParser: true, useUnifiedTopology: true });
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+const register = data => request(app).post('/auth/register').send(data);
+
+describe('auth extra', () => {
+  test('sanitizes unexpected role', async () => {
+    const res = await register({ name: 'x', email: 'x@e.com', password: 'p', role: 'super' });
+    const payload = jwt.verify(res.body.token, process.env.JWT_SECRET);
+    expect(payload.role).toBe('user');
+  });
+
+  test('login fails for non existing user', async () => {
+    const res = await request(app).post('/auth/login').send({ email: 'no@e.com', password: 'p' });
+    expect(res.status).toBe(401);
+  });
+
+  test('profile requires token header', async () => {
+    await register({ name: 'u', email: 'u@e.com', password: 'p' });
+    const res = await request(app).get('/auth/profile');
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/generated/routes/booksExtra.test.js
+++ b/tests/generated/routes/booksExtra.test.js
@@ -1,0 +1,51 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const app = require('../../../app');
+const Book = require('../../../models/Book');
+let mongoServer;
+let adminToken;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongoServer = await MongoMemoryServer.create({ binary: { version: '4.4.10' } });
+  await mongoose.connect(mongoServer.getUri(), { useNewUrlParser: true, useUnifiedTopology: true });
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+const register = async role => {
+  const res = await request(app).post('/auth/register').send({ name: role, email: `${role}@e.com`, password: 'pass', role });
+  return res.body.token;
+};
+
+describe('books extra', () => {
+  beforeEach(async () => {
+    adminToken = await register('admin');
+  });
+
+  test('update and delete not found return 404', async () => {
+    const upd = await request(app).put('/books/507f1f77bcf86cd799439011').set('Authorization', `Bearer ${adminToken}`).send({ title: 'x' });
+    expect(upd.status).toBe(404);
+    const del = await request(app).delete('/books/507f1f77bcf86cd799439011').set('Authorization', `Bearer ${adminToken}`);
+    expect(del.status).toBe(404);
+  });
+
+  test('update requires valid token', async () => {
+    const book = await Book.create({ title: 'b' });
+    const res = await request(app).put(`/books/${book._id}`).send({ title: 'bb' });
+    expect(res.status).toBe(401);
+  });
+
+  test('handle invalid book id', async () => {
+    const res = await request(app).get('/books/invalid-id');
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/generated/routes/rentalsExtra.test.js
+++ b/tests/generated/routes/rentalsExtra.test.js
@@ -1,0 +1,64 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const app = require('../../../app');
+const Book = require('../../../models/Book');
+let mongoServer;
+let tokenA;
+let tokenB;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongoServer = await MongoMemoryServer.create({ binary: { version: '4.4.10' } });
+  await mongoose.connect(mongoServer.getUri(), { useNewUrlParser: true, useUnifiedTopology: true });
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+const register = async name => {
+  const res = await request(app).post('/auth/register').send({ name, email: `${name}@e.com`, password: 'pass' });
+  return res.body.token;
+};
+
+describe('rentals extra', () => {
+  beforeEach(async () => {
+    tokenA = await register('a');
+    tokenB = await register('b');
+  });
+
+  test('returning twice yields error', async () => {
+    const book = await Book.create({ title: 'b', stock: 1 });
+    await request(app).post('/rentals').set('Authorization', `Bearer ${tokenA}`).send({ bookId: book._id });
+    await request(app).post('/rentals/return').set('Authorization', `Bearer ${tokenA}`).send({ bookId: book._id });
+    const res = await request(app).post('/rentals/return').set('Authorization', `Bearer ${tokenA}`).send({ bookId: book._id });
+    expect(res.status).toBe(400);
+  });
+
+  test('book becomes rentable after return', async () => {
+    const book = await Book.create({ title: 'b', stock: 1 });
+    await request(app).post('/rentals').set('Authorization', `Bearer ${tokenA}`).send({ bookId: book._id });
+    await request(app).post('/rentals/return').set('Authorization', `Bearer ${tokenA}`).send({ bookId: book._id });
+    const rentB = await request(app).post('/rentals').set('Authorization', `Bearer ${tokenB}`).send({ bookId: book._id });
+    expect(rentB.status).toBe(201);
+  });
+
+  test('history empty when no rentals', async () => {
+    const res = await request(app).get('/rentals/history').set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  test('invalid book id returns error', async () => {
+    const rent = await request(app).post('/rentals').set('Authorization', `Bearer ${tokenA}`).send({ bookId: 'bad' });
+    expect(rent.status).toBe(500);
+    const ret = await request(app).post('/rentals/return').set('Authorization', `Bearer ${tokenA}`).send({ bookId: 'bad' });
+    expect(ret.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- enhance auth tests for login failure, role sanitization, and missing token
- cover books not-found and invalid-id paths
- add rental edge cases: double return, rent after return, empty history, invalid IDs

## Testing
- `npm test` *(fails: DownloadError for MongoMemoryServer)*

------
https://chatgpt.com/codex/tasks/task_e_685277d9b7808333a3b3d17b77848237