### PR TITLE
Add Jest tests for API endpoints

### DIFF
--- a/tests/generated/routes/auth.test.js
+++ b/tests/generated/routes/auth.test.js
@@ -1,0 +1,72 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const jwt = require('jsonwebtoken');
+const app = require('../../../app');
+const User = require('../../../models/user');
+
+let mongoServer;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongoServer = await MongoMemoryServer.create({ binary: { version: '4.4.10' } });
+  await mongoose.connect(mongoServer.getUri(), { useNewUrlParser: true, useUnifiedTopology: true });
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('auth routes', () => {
+  test('registers a user and hashes password', async () => {
+    const res = await request(app).post('/auth/register').send({ name: 't', email: 't@e.com', password: 'pass' });
+    expect(res.status).toBe(201);
+    expect(res.body.token).toBeDefined();
+    const user = await User.findOne({ email: 't@e.com' });
+    expect(user).toBeTruthy();
+    expect(user.password).not.toBe('pass');
+  });
+
+  test('prevents duplicate registration', async () => {
+    await request(app).post('/auth/register').send({ name: 't', email: 'dup@e.com', password: 'pass' });
+    const res = await request(app).post('/auth/register').send({ name: 't', email: 'dup@e.com', password: 'pass' });
+    expect(res.status).toBe(400);
+  });
+
+  test('registers admin role', async () => {
+    const res = await request(app).post('/auth/register').send({ name: 'admin', email: 'admin@e.com', password: 'pass', role: 'admin' });
+    const payload = jwt.verify(res.body.token, process.env.JWT_SECRET);
+    expect(payload.role).toBe('admin');
+  });
+
+  test('logs in with valid credentials', async () => {
+    await request(app).post('/auth/register').send({ name: 'u', email: 'login@e.com', password: 'pass' });
+    const res = await request(app).post('/auth/login').send({ email: 'login@e.com', password: 'pass' });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  test('rejects login with wrong password', async () => {
+    await request(app).post('/auth/register').send({ name: 'u', email: 'wrong@e.com', password: 'pass' });
+    const res = await request(app).post('/auth/login').send({ email: 'wrong@e.com', password: 'bad' });
+    expect(res.status).toBe(401);
+  });
+
+  test('returns profile for authenticated user', async () => {
+    const reg = await request(app).post('/auth/register').send({ name: 'u', email: 'prof@e.com', password: 'pass' });
+    const res = await request(app).get('/auth/profile').set('Authorization', `Bearer ${reg.body.token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.email).toBe('prof@e.com');
+    expect(res.body.password).toBeUndefined();
+  });
+
+  test('rejects profile access with invalid token', async () => {
+    const res = await request(app).get('/auth/profile').set('Authorization', 'Bearer bad');
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/generated/routes/authExtra.test.js
+++ b/tests/generated/routes/authExtra.test.js
@@ -1,0 +1,42 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const jwt = require('jsonwebtoken');
+const app = require('../../../app');
+let mongoServer;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongoServer = await MongoMemoryServer.create({ binary: { version: '4.4.10' } });
+  await mongoose.connect(mongoServer.getUri(), { useNewUrlParser: true, useUnifiedTopology: true });
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+const register = data => request(app).post('/auth/register').send(data);
+
+describe('auth extra', () => {
+  test('sanitizes unexpected role', async () => {
+    const res = await register({ name: 'x', email: 'x@e.com', password: 'p', role: 'super' });
+    const payload = jwt.verify(res.body.token, process.env.JWT_SECRET);
+    expect(payload.role).toBe('user');
+  });
+
+  test('login fails for non existing user', async () => {
+    const res = await request(app).post('/auth/login').send({ email: 'no@e.com', password: 'p' });
+    expect(res.status).toBe(401);
+  });
+
+  test('profile requires token header', async () => {
+    await register({ name: 'u', email: 'u@e.com', password: 'p' });
+    const res = await request(app).get('/auth/profile');
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/generated/routes/books.test.js
+++ b/tests/generated/routes/books.test.js
@@ -1,0 +1,86 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const app = require('../../../app');
+const Book = require('../../../models/Book');
+let mongoServer;
+let adminToken;
+let userToken;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongoServer = await MongoMemoryServer.create({ binary: { version: '4.4.10' } });
+  await mongoose.connect(mongoServer.getUri(), { useNewUrlParser: true, useUnifiedTopology: true });
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+const registerUser = async (role = 'user') => {
+  const res = await request(app).post('/auth/register').send({ name: role, email: `${role}@e.com`, password: 'pass', role });
+  return res.body.token;
+};
+
+describe('books routes', () => {
+  beforeEach(async () => {
+    adminToken = await registerUser('admin');
+    userToken = await registerUser('user2');
+  });
+
+  test('gets empty books list', async () => {
+    const res = await request(app).get('/books');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  test('admin adds a book', async () => {
+    const res = await request(app).post('/books').set('Authorization', `Bearer ${adminToken}`).send({ title: 'b', author: 'a', stock: 2 });
+    expect(res.status).toBe(201);
+    expect(res.body.title).toBe('b');
+    const books = await Book.find();
+    expect(books.length).toBe(1);
+  });
+
+  test('non admin cannot add book', async () => {
+    const res = await request(app).post('/books').set('Authorization', `Bearer ${userToken}`).send({ title: 'b' });
+    expect(res.status).toBe(403);
+  });
+
+  test('unauthenticated add book denied', async () => {
+    const res = await request(app).post('/books').send({ title: 'b' });
+    expect(res.status).toBe(401);
+  });
+
+  test('gets book by id and handles not found', async () => {
+    const created = await request(app).post('/books').set('Authorization', `Bearer ${adminToken}`).send({ title: 'b', author: 'a', stock: 1 });
+    const found = await request(app).get(`/books/${created.body._id}`);
+    expect(found.status).toBe(200);
+    expect(found.body.title).toBe('b');
+    const nf = await request(app).get('/books/507f1f77bcf86cd799439011');
+    expect(nf.status).toBe(404);
+  });
+
+  test('updates and deletes book as admin', async () => {
+    const created = await request(app).post('/books').set('Authorization', `Bearer ${adminToken}`).send({ title: 'b', author: 'a', stock: 1 });
+    const upd = await request(app).put(`/books/${created.body._id}`).set('Authorization', `Bearer ${adminToken}`).send({ title: 'bb' });
+    expect(upd.status).toBe(200);
+    expect(upd.body.title).toBe('bb');
+    const del = await request(app).delete(`/books/${created.body._id}`).set('Authorization', `Bearer ${adminToken}`);
+    expect(del.status).toBe(200);
+    expect(del.body.message).toBe('Book deleted');
+  });
+
+  test('update and delete forbidden for user', async () => {
+    const created = await request(app).post('/books').set('Authorization', `Bearer ${adminToken}`).send({ title: 'b', stock: 1 });
+    const upd = await request(app).put(`/books/${created.body._id}`).set('Authorization', `Bearer ${userToken}`).send({ title: 'bb' });
+    expect(upd.status).toBe(403);
+    const del = await request(app).delete(`/books/${created.body._id}`).set('Authorization', `Bearer ${userToken}`);
+    expect(del.status).toBe(403);
+  });
+});

--- a/tests/generated/routes/booksExtra.test.js
+++ b/tests/generated/routes/booksExtra.test.js
@@ -1,0 +1,51 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const app = require('../../../app');
+const Book = require('../../../models/Book');
+let mongoServer;
+let adminToken;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongoServer = await MongoMemoryServer.create({ binary: { version: '4.4.10' } });
+  await mongoose.connect(mongoServer.getUri(), { useNewUrlParser: true, useUnifiedTopology: true });
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+const register = async role => {
+  const res = await request(app).post('/auth/register').send({ name: role, email: `${role}@e.com`, password: 'pass', role });
+  return res.body.token;
+};
+
+describe('books extra', () => {
+  beforeEach(async () => {
+    adminToken = await register('admin');
+  });
+
+  test('update and delete not found return 404', async () => {
+    const upd = await request(app).put('/books/507f1f77bcf86cd799439011').set('Authorization', `Bearer ${adminToken}`).send({ title: 'x' });
+    expect(upd.status).toBe(404);
+    const del = await request(app).delete('/books/507f1f77bcf86cd799439011').set('Authorization', `Bearer ${adminToken}`);
+    expect(del.status).toBe(404);
+  });
+
+  test('update requires valid token', async () => {
+    const book = await Book.create({ title: 'b' });
+    const res = await request(app).put(`/books/${book._id}`).send({ title: 'bb' });
+    expect(res.status).toBe(401);
+  });
+
+  test('handle invalid book id', async () => {
+    const res = await request(app).get('/books/invalid-id');
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/generated/routes/rentals.test.js
+++ b/tests/generated/routes/rentals.test.js
@@ -1,0 +1,94 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const app = require('../../../app');
+const Book = require('../../../models/Book');
+const Rental = require('../../../models/Rental');
+let mongoServer;
+let userToken;
+let otherToken;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongoServer = await MongoMemoryServer.create({ binary: { version: '4.4.10' } });
+  await mongoose.connect(mongoServer.getUri(), { useNewUrlParser: true, useUnifiedTopology: true });
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+const register = async name => {
+  const res = await request(app).post('/auth/register').send({ name, email: `${name}@e.com`, password: 'pass' });
+  return res.body.token;
+};
+
+describe('rental routes', () => {
+  beforeEach(async () => {
+    userToken = await register('user');
+    otherToken = await register('other');
+  });
+
+  test('rents and returns a book', async () => {
+    const book = await Book.create({ title: 'b', author: 'a', stock: 1 });
+    const rent = await request(app).post('/rentals').set('Authorization', `Bearer ${userToken}`).send({ bookId: book._id });
+    expect(rent.status).toBe(201);
+    const stored = await Book.findById(book._id);
+    expect(stored.stock).toBe(0);
+    const ret = await request(app).post('/rentals/return').set('Authorization', `Bearer ${userToken}`).send({ bookId: book._id });
+    expect(ret.status).toBe(200);
+    expect(ret.body.message).toBe('Book returned');
+    const updated = await Book.findById(book._id);
+    expect(updated.stock).toBe(1);
+  });
+
+  test('cannot rent unavailable book', async () => {
+    const book = await Book.create({ title: 'b', stock: 0 });
+    const res = await request(app).post('/rentals').set('Authorization', `Bearer ${userToken}`).send({ bookId: book._id });
+    expect(res.status).toBe(400);
+  });
+
+  test('renting same book twice when stock runs out fails', async () => {
+    const book = await Book.create({ title: 'b', stock: 1 });
+    await request(app).post('/rentals').set('Authorization', `Bearer ${userToken}`).send({ bookId: book._id });
+    const res = await request(app).post('/rentals').set('Authorization', `Bearer ${userToken}`).send({ bookId: book._id });
+    expect(res.status).toBe(400);
+  });
+
+  test('returning without active rental', async () => {
+    const book = await Book.create({ title: 'b', stock: 1 });
+    const res = await request(app).post('/rentals/return').set('Authorization', `Bearer ${userToken}`).send({ bookId: book._id });
+    expect(res.status).toBe(400);
+  });
+
+  test('other user cannot return rental', async () => {
+    const book = await Book.create({ title: 'b', stock: 1 });
+    await request(app).post('/rentals').set('Authorization', `Bearer ${userToken}`).send({ bookId: book._id });
+    const res = await request(app).post('/rentals/return').set('Authorization', `Bearer ${otherToken}`).send({ bookId: book._id });
+    expect(res.status).toBe(400);
+  });
+
+  test('history returns rentals for user', async () => {
+    const book = await Book.create({ title: 'b', stock: 2 });
+    await request(app).post('/rentals').set('Authorization', `Bearer ${userToken}`).send({ bookId: book._id });
+    await request(app).post('/rentals/return').set('Authorization', `Bearer ${userToken}`).send({ bookId: book._id });
+    const res = await request(app).get('/rentals/history').set('Authorization', `Bearer ${userToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+  });
+
+  test('authentication required for rental actions', async () => {
+    const book = await Book.create({ title: 'b', stock: 1 });
+    const rent = await request(app).post('/rentals').send({ bookId: book._id });
+    expect(rent.status).toBe(401);
+    const ret = await request(app).post('/rentals/return').send({ bookId: book._id });
+    expect(ret.status).toBe(401);
+    const hist = await request(app).get('/rentals/history');
+    expect(hist.status).toBe(401);
+  });
+});

--- a/tests/generated/routes/rentalsExtra.test.js
+++ b/tests/generated/routes/rentalsExtra.test.js
@@ -1,0 +1,64 @@
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const app = require('../../../app');
+const Book = require('../../../models/Book');
+let mongoServer;
+let tokenA;
+let tokenB;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  mongoServer = await MongoMemoryServer.create({ binary: { version: '4.4.10' } });
+  await mongoose.connect(mongoServer.getUri(), { useNewUrlParser: true, useUnifiedTopology: true });
+});
+
+afterEach(async () => {
+  await mongoose.connection.db.dropDatabase();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+const register = async name => {
+  const res = await request(app).post('/auth/register').send({ name, email: `${name}@e.com`, password: 'pass' });
+  return res.body.token;
+};
+
+describe('rentals extra', () => {
+  beforeEach(async () => {
+    tokenA = await register('a');
+    tokenB = await register('b');
+  });
+
+  test('returning twice yields error', async () => {
+    const book = await Book.create({ title: 'b', stock: 1 });
+    await request(app).post('/rentals').set('Authorization', `Bearer ${tokenA}`).send({ bookId: book._id });
+    await request(app).post('/rentals/return').set('Authorization', `Bearer ${tokenA}`).send({ bookId: book._id });
+    const res = await request(app).post('/rentals/return').set('Authorization', `Bearer ${tokenA}`).send({ bookId: book._id });
+    expect(res.status).toBe(400);
+  });
+
+  test('book becomes rentable after return', async () => {
+    const book = await Book.create({ title: 'b', stock: 1 });
+    await request(app).post('/rentals').set('Authorization', `Bearer ${tokenA}`).send({ bookId: book._id });
+    await request(app).post('/rentals/return').set('Authorization', `Bearer ${tokenA}`).send({ bookId: book._id });
+    const rentB = await request(app).post('/rentals').set('Authorization', `Bearer ${tokenB}`).send({ bookId: book._id });
+    expect(rentB.status).toBe(201);
+  });
+
+  test('history empty when no rentals', async () => {
+    const res = await request(app).get('/rentals/history').set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  test('invalid book id returns error', async () => {
+    const rent = await request(app).post('/rentals').set('Authorization', `Bearer ${tokenA}`).send({ bookId: 'bad' });
+    expect(rent.status).toBe(500);
+    const ret = await request(app).post('/rentals/return').set('Authorization', `Bearer ${tokenA}`).send({ bookId: 'bad' });
+    expect(ret.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- implement comprehensive Jest tests for auth, books, and rentals routes
- cover edge cases with additional test files

## Testing
- `npm test` *(fails: cannot download MongoDB binaries)*

------
https://chatgpt.com/codex/tasks/task_e_686273ea94088333944eba0d7010d7f1